### PR TITLE
[SBX-1044] Add header and logo component

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -62,7 +62,7 @@
             "position": "before"
           },
           {
-            "pattern": "@olist/+(united|ui-commons)",
+            "pattern": "@olist/**",
             "group": "external",
             "position": "after"
           }

--- a/public/locales/en/logo.json
+++ b/public/locales/en/logo.json
@@ -1,0 +1,3 @@
+{
+  "logoSlogan": "track your orders"
+}

--- a/public/locales/pt/logo.json
+++ b/public/locales/pt/logo.json
@@ -1,0 +1,3 @@
+{
+  "logoSlogan": "acompanhe seus pedidos"
+}

--- a/src/common/components/Logo.stories.tsx
+++ b/src/common/components/Logo.stories.tsx
@@ -1,0 +1,30 @@
+import { ReactElement } from 'react';
+
+import { Flex, Box } from '@olist/united';
+
+import Logo from './Logo';
+
+export const Example = (): ReactElement => {
+  return (
+    <Flex>
+      <Box>
+        <Logo variation="vertical" />
+      </Box>
+      <Box>
+        <Logo />
+      </Box>
+    </Flex>
+  );
+};
+
+export default {
+  title: 'Common/Components/Logo',
+  component: Logo,
+  parameters: {
+    docs: {
+      description: {
+        component: "It's the project logo, it combines the olist store logo to the common slogan",
+      },
+    },
+  },
+};

--- a/src/common/components/Logo.tsx
+++ b/src/common/components/Logo.tsx
@@ -1,0 +1,49 @@
+import { ReactElement } from 'react';
+import { useTranslation } from 'react-i18next';
+
+import { LogoOlistStore } from '@olist/ui-commons/dist/ui-commons.cjs';
+import { Flex, Box, Text } from '@olist/united';
+
+interface LogoProps {
+  variation?: 'vertical' | 'horizontal';
+}
+
+const defaultProps: LogoProps = {
+  variation: 'horizontal',
+};
+
+function Logo({ variation }: LogoProps): ReactElement {
+  const { t } = useTranslation('logo');
+
+  const vertical = {
+    alignItems: 'center',
+    flexDirection: 'column',
+  };
+
+  const horizontal = {
+    alignItems: 'center',
+  };
+
+  const position = {
+    vertical,
+    horizontal,
+  }[variation];
+
+  const isVertical = variation === 'vertical';
+  const isHorizontal = variation === 'horizontal';
+
+  return (
+    <Flex {...position}>
+      <Box mb={isVertical ? '24px' : 0} mr={isHorizontal ? '24px' : 0}>
+        <LogoOlistStore variation="default" />
+      </Box>
+      <Box>
+        <Text.H4 color="foundation.primaryDark">{t('logoSlogan')}</Text.H4>
+      </Box>
+    </Flex>
+  );
+}
+
+Logo.defaultProps = defaultProps;
+
+export default Logo;

--- a/src/common/layouts/Layout.tsx
+++ b/src/common/layouts/Layout.tsx
@@ -1,7 +1,8 @@
-import { Layout as UiCommonsLayout } from '@olist/ui-commons/dist/ui-commons.cjs';
 import { themeGet } from '@styled-system/theme-get';
 import { ReactElement } from 'react';
 import styled from 'styled-components';
+
+import { Layout as UiCommonsLayout } from '@olist/ui-commons/dist/ui-commons.cjs';
 
 interface Layout {
   children: JSX.Element[] | JSX.Element;

--- a/src/common/utils/i18n.ts
+++ b/src/common/utils/i18n.ts
@@ -1,6 +1,7 @@
-import { i18nextFormatCallback } from '@olist/ui-commons/dist/helpers.cjs.js';
 import i18n from 'i18next';
 import { initReactI18next } from 'react-i18next';
+
+import { i18nextFormatCallback } from '@olist/ui-commons/dist/helpers.cjs.js';
 
 import resources from '../../../public/locales/index.js';
 

--- a/src/home/components/Header.tsx
+++ b/src/home/components/Header.tsx
@@ -1,0 +1,15 @@
+import { ReactElement } from 'react';
+
+import { Flex } from '@olist/united';
+
+import Logo from '~/common/components/Logo';
+
+const Header = (): ReactElement => {
+  return (
+    <Flex justifyContent="center" mt={5}>
+      <Logo variation="vertical" />
+    </Flex>
+  );
+};
+
+export default Header;

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,11 +1,12 @@
 import { ReactElement } from 'react';
 
+import Header from '~/home/components/Header';
 import Layout from '~common/layouts/Layout';
 
 const HomePage = (): ReactElement => {
   return (
     <Layout>
-      <div>body</div>
+      <Header />
     </Layout>
   );
 };


### PR DESCRIPTION
#### What
- Add Header component for page
- Add Logo component with variation for horizontal e vertical

#### Why
The home page headers is a littler different from the details page, based on that I need a logo with variations and different headers to simplify the layout creation

`Story`: https://jira-olist.atlassian.net/browse/SBX-1023
`Task`: https://jira-olist.atlassian.net/browse/SBX-1044

---

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/30416520/110993459-16549480-8356-11eb-85d8-45103cf7308e.png)
