### PR TITLE
[SBX-1069] Add OrderInfo component to Order Details page

### DIFF
--- a/public/locales/en/orderDetailsOrderInfo.json
+++ b/public/locales/en/orderDetailsOrderInfo.json
@@ -1,0 +1,4 @@
+{
+  "translatedEstimatedToFinalDate": "arriving between {{dateOne, dateTimeFormatAsShort}} and {{dateTwo, dateTimeFormatAsShort}}",
+  "{{date, dateTimeFormatAsShort}}": "{{date, dateTimeFormatAsShort}}"
+}

--- a/public/locales/pt/orderDetailsOrderInfo.json
+++ b/public/locales/pt/orderDetailsOrderInfo.json
@@ -1,0 +1,4 @@
+{
+  "translatedEstimatedToFinalDate": "chegando entre {{dateOne, dateTimeFormatAsShort}} e {{dateTwo, dateTimeFormatAsShort}}",
+  "{{date, dateTimeFormatAsShort}}": "{{date, dateTimeFormatAsShort}}"
+}

--- a/src/common/components/InputWithFieldError/index.tsx
+++ b/src/common/components/InputWithFieldError/index.tsx
@@ -1,5 +1,4 @@
 import { themeGet } from '@styled-system/theme-get';
-import { ReactElement } from 'react';
 import styled, { css } from 'styled-components';
 
 import { Box, FieldError, Input as UnitedInput } from '@olist/united';

--- a/src/order-details/components/OrderInfo/OrderInfo.stories.tsx
+++ b/src/order-details/components/OrderInfo/OrderInfo.stories.tsx
@@ -1,0 +1,25 @@
+import OrderInfo from './OrderInfo';
+
+export const Example = () => {
+  return (
+    <OrderInfo
+      channel="Mercado Livre"
+      orderId="#4225526010"
+      createdAt={new Date().toISOString()}
+      estimatedDeliveryAt={new Date().toISOString()}
+      finalDeliveryAt={new Date().toISOString()}
+    />
+  );
+};
+
+export default {
+  title: 'Order Details/Components/Order Info',
+  parameters: {
+    docs: {
+      description: {
+        component:
+          'This component is the principal source of information about the order inside the details page .',
+      },
+    },
+  },
+};

--- a/src/order-details/components/OrderInfo/OrderInfo.tsx
+++ b/src/order-details/components/OrderInfo/OrderInfo.tsx
@@ -1,0 +1,40 @@
+import { useTranslation } from 'react-i18next';
+
+import { Box, Text } from '@olist/united';
+
+export interface OrderInfoProps {
+  channel: string;
+  orderId: string;
+  createdAt: string;
+  estimatedDeliveryAt?: string;
+  finalDeliveryAt?: string;
+}
+
+export default function OrderInfo({
+  channel,
+  createdAt,
+  estimatedDeliveryAt,
+  finalDeliveryAt,
+  orderId,
+}: OrderInfoProps) {
+  const { t } = useTranslation('orderDetailsOrderInfo');
+
+  const translatedCreatedAt = t('{{date, dateTimeFormatAsShort}}', {
+    date: new Date(createdAt),
+  });
+  /* arriving between {{dateOne, dateTimeFormatAsShort}} and {{dateTwo, dateTimeFormatAsShort}} */
+  const translatedEstimatedToFinalDate = t('translatedEstimatedToFinalDate', {
+    dateOne: new Date(estimatedDeliveryAt),
+    dateTwo: new Date(finalDeliveryAt),
+  });
+
+  return (
+    <Box>
+      <Text.H3 fontWeight="bold">
+        {channel} {orderId}
+      </Text.H3>
+      <Text>{translatedCreatedAt}</Text>
+      <Text>{translatedEstimatedToFinalDate}</Text>
+    </Box>
+  );
+}

--- a/src/order-details/components/OrderInfo/OrderInfo.tsx
+++ b/src/order-details/components/OrderInfo/OrderInfo.tsx
@@ -22,7 +22,7 @@ export default function OrderInfo({
   const translatedCreatedAt = t('{{date, dateTimeFormatAsShort}}', {
     date: new Date(createdAt),
   });
-  /* arriving between {{dateOne, dateTimeFormatAsShort}} and {{dateTwo, dateTimeFormatAsShort}} */
+
   const translatedEstimatedToFinalDate = t('translatedEstimatedToFinalDate', {
     dateOne: new Date(estimatedDeliveryAt),
     dateTwo: new Date(finalDeliveryAt),
@@ -34,7 +34,7 @@ export default function OrderInfo({
         {channel} {orderId}
       </Text.H3>
       <Text>{translatedCreatedAt}</Text>
-      <Text>{translatedEstimatedToFinalDate}</Text>
+      <Text color="foundation.shadeDark">{translatedEstimatedToFinalDate}</Text>
     </Box>
   );
 }

--- a/src/order-details/components/OrderInfo/index.tsx
+++ b/src/order-details/components/OrderInfo/index.tsx
@@ -1,0 +1,1 @@
+export { default } from './OrderInfo';

--- a/src/pages/order-details.tsx
+++ b/src/pages/order-details.tsx
@@ -1,10 +1,22 @@
+import { Flex } from '@olist/united';
+
 import Layout from '~/common/layouts/Layout';
 import Header from '~/order-details/components/Header';
+import OrderInfo from '~/order-details/components/OrderInfo';
 
 const OrdersDetails = () => {
   return (
     <Layout>
       <Header />
+      <Flex mt={10}>
+        <OrderInfo
+          channel="Mercado Livre"
+          orderId="#4225526010"
+          createdAt={new Date().toISOString()}
+          estimatedDeliveryAt={new Date().toISOString()}
+          finalDeliveryAt={new Date().toISOString()}
+        />
+      </Flex>
     </Layout>
   );
 };


### PR DESCRIPTION
#### What
- Add OrderInfo component
- Resolve eslint warning
- Add OrderInfo to Order Details page

#### Why
This component will show the basic and important information of the current Order for the Buyer.

`Story`: https://jira-olist.atlassian.net/browse/SBX-1024
`Task`: https://jira-olist.atlassian.net/browse/SBX-1067

---

#### Screenshots (if appropriate)
![image](https://user-images.githubusercontent.com/30416520/112534674-1c9d3480-8d8a-11eb-9046-26370619f5a0.png)
